### PR TITLE
recognise cookie without spaces between attributes

### DIFF
--- a/xmlhttprequest-cookie-obj.js
+++ b/xmlhttprequest-cookie-obj.js
@@ -86,7 +86,7 @@ Cookie.build = function (cookieString, url) {
 
     /*  parse value/name  */
     var equalsSplit = /([^=]+)(?:=(.*))?/;
-    var cookieParams = ("" + cookieString).split("; ");
+    var cookieParams = ("" + cookieString).split(/;\s*/);
     var cookieParam;
     if ((cookieParam = cookieParams.shift().match(equalsSplit)) === null)
         throw new Error("failed to parse cookie string");


### PR DESCRIPTION
changed split to use regex matching ; + any amount of whitespace