### PR TITLE
Fixed parsing cookie values without spaces after each semicolon

### DIFF
--- a/xmlhttprequest-cookie-obj.js
+++ b/xmlhttprequest-cookie-obj.js
@@ -86,7 +86,7 @@ Cookie.build = function (cookieString, url) {
 
     /*  parse value/name  */
     var equalsSplit = /([^=]+)(?:=(.*))?/;
-    var cookieParams = ("" + cookieString).split("; ");
+    var cookieParams = ("" + cookieString).split(";");
     var cookieParam;
     if ((cookieParam = cookieParams.shift().match(equalsSplit)) === null)
         throw new Error("failed to parse cookie string");


### PR DESCRIPTION
Hi Ralf,
I've encountered some web server implementation (Jetty) that uses cookie value semicolon (;) character separators without the additional space you require for argument split. 
I've tried to understand if the whitespace is actually part of the RFC but it seems that it is allowed and often used for readibility reason.
With this change it is possible to correctly parse the classic JSESSION cookies coming from Jetty. I hope this can be merged without issues.

Thank you!
 Luciano

Ref. http://tools.ietf.org/html/rfc6265